### PR TITLE
Change the format string so that Vicare will accept it too.

### DIFF
--- a/nanopass/records.ss
+++ b/nanopass/records.ss
@@ -649,7 +649,7 @@
                                  #`(lambda (x)
                                      (unless (pred? x)
                                        (errorf who
-                                         "expected ~s but received ~s in field ~s of ~s~:[~; from ~:*~a~]"
+                                         "expected ~s but received ~s in field ~s of ~s[ from ~a]"
                                          '#,name x '#,fld '#,(alt-syn alt) #,msg)))
                                  #`(lambda (x)
                                      (for-each #,(f (fx- level 1)) x))))


### PR DESCRIPTION
Vicare didn't like the `~:` in the format string. I'm not really sure what it does, but this version works in Vicare.
